### PR TITLE
Remove redundant anti-duplication code from totals counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ hash there is a `legislatures` array which has a `terms` hash with one
 entry for each term we have details for and a `totals` hash which has
 counts across all terms that we have details for.
 
-In these totals if someone is listed in one term as unknown and
-another with a confirmed gender, they will be counted under the
-confirmed gender.
-
 Each of these also contain breakdowns per party. Note that it's possible
 that a person could be counted twice in the party data if they have
 changed party.

--- a/app.rb
+++ b/app.rb
@@ -54,15 +54,8 @@ class GenderStats
 
         l.popolo.persons.each do |p|
           gender = p.gender || 'unknown'
-          if not totals_seen[p.id]
-              totals[:overall][gender] += 1
-              totals[:overall][:total] += 1
-              totals_seen[p.id] = gender
-          elsif totals_seen[p.id] != gender and gender != 'unknown'
-              totals[:overall][gender] += 1
-              totals[:overall][totals_seen[p.id]] -= 1
-              totals_seen[p.id] = gender
-          end
+          totals[:overall][gender] += 1
+          totals[:overall][:total] += 1
           person_memberships[p.id].each do |m|
             term_id = m.document[:legislative_period_id]
             terms[term_id][:overall][gender] += 1
@@ -83,10 +76,6 @@ class GenderStats
                 totals[:parties][party][:name] = party_id_to_name[group_id]
                 totals[:parties][party][gender] += 1
                 totals[:parties][party][:total] += 1
-                totals_seen[party_person] = gender
-            elsif totals_seen[party_person] != gender and gender != 'unknown'
-                totals[:overall][party][gender] += 1
-                totals[:overall][party][totals_seen[party_person]] -= 1
                 totals_seen[party_person] = gender
             end
           end


### PR DESCRIPTION
Removes code that was preventing duplication that could never happen in the overall totals and also code that was checking for a change of gender that would never happen in the group totals.
